### PR TITLE
:bug: Invalid SemVer breaks Exporting

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -14,7 +14,7 @@ const sanitizeSemVer = (semver) => {
 	if (semver === 0) return "0.0.0"
 	if (semver === "0") return "0.0.0"
 
-  const sanitize = (point) => point.toString().replace(/[^0-9]/g, '')
+  const sanitize = (point) => parseInt(point.toString().replace(/[^0-9]/g, ''))
 
   const x = semver.split('.')
 

--- a/src/lib/writeSketchpack.js
+++ b/src/lib/writeSketchpack.js
@@ -1,16 +1,17 @@
 const {reduce} = require('lodash')
 const semver = require('semver')
 const jsonfile = require('jsonfile')
+const {sanitizeSemVer} = require('./utils')
 
 const writeSketchpack = (filepath, contents) => {
   const reducedPlugins = (collection) => reduce(collection, ((result, value, key) => {
     result[`${value.owner.handle}/${value.name}`] = {
       name: value.name,
       owner: value.owner.handle,
-      version: value.version || "^0.0.0",
-      version_range: semver.toComparators(value.version || "^0.0.0")[0],
-      compatible_version: value.compatible_version || "^0.0.0",
-      compatible_version_range: semver.toComparators(value.compatible_version || "^0.0.0")[0],
+      version: sanitizeSemVer(value.version) || "0.0.0",
+      version_range: semver.toComparators(sanitizeSemVer(value.version) || "0.0.0")[0],
+      compatible_version: sanitizeSemVer(value.compatible_version) || "0.0.0",
+      compatible_version_range: semver.toComparators(sanitizeSemVer(value.compatible_version) || "0.0.0")[0],
     }
 
     return result


### PR DESCRIPTION
Exporting breaks when invalid SemVers (e.g. `3.03`) are used.

Fixes #39